### PR TITLE
Fix issue with non apple homekit apps status reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ LockitronAccessory.prototype.getState = function(callback) {
       var json = JSON.parse(body);
       var state = json.state; // "lock" or "unlock"
       this.log("Lock state is %s", state);
-      var locked = state == "lock"
+      var locked =(state == "lock") ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED;
       callback(null, locked); // success
     }
     else {


### PR DESCRIPTION
Non apple homekit apps were showing values of 1.0 and 0.0 instead of secured and unsecured status on initial request for status.
After setting new state proper status was showing but would then revert back to showing 1.0 and 0.0.
Added simple fix for this issue in non apple homekit apps.